### PR TITLE
Renamed services.dist.yml to services.yml.dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Minimizing conflict issues occured by single-file  based services.yml dependency
             bundles: ["ApiBundle"]
             
 
-- Change `services.yml` to `services.dist.yml`
+- Change `services.yml` to `services.yml.dist`
         
 - Add `services.yml` to .gitignore
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -69,7 +69,7 @@ class Builder
             }, $dependencies);
 
             // Read yaml dist
-            $distPath = sprintf('%s/Resources/config/services.dist.yml', $bundleDir);
+            $distPath = sprintf('%s/Resources/config/services.yml.dist', $bundleDir);
             $yaml = $this->yamlParser->parse($distPath);
             $yaml = $yaml ? $yaml : ['services' => []];
 

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -21,7 +21,7 @@ class BuilderTest extends BaseTestCase
                 ],
                 'dir' => 'src/TestBundle1',
                 'yamlPath' => 'src/TestBundle1/Resources/config/services.yml',
-                'distPath' => 'src/TestBundle1/Resources/config/services.dist.yml',
+                'distPath' => 'src/TestBundle1/Resources/config/services.yml.dist',
                 'distYaml' => [
                     'services' => [
                         'test_bundle_dist1.di1' => [
@@ -45,7 +45,7 @@ class BuilderTest extends BaseTestCase
                 ],
                 'dir' => 'src/TestBundle2',
                 'yamlPath' => 'src/TestBundle2/Resources/config/services.yml',
-                'distPath' => 'src/TestBundle2/Resources/config/services.dist.yml',
+                'distPath' => 'src/TestBundle2/Resources/config/services.yml.dist',
                 'distYaml' => [
                     'services' => [
                         'test_bundle_dist2.di1' => [


### PR DESCRIPTION
Renamed default service yaml file moved dist extension end of the name for best practice. 
For IDE (PHPStorm) support; 
- Open Preferences -> Editor -> File Types
- Select YAML from Recognized File Types
- Add *.yml.dist to Registered Patterns